### PR TITLE
Replace newStartTime with newEndTime

### DIFF
--- a/src/features/time-duration-calculator/components/time-form.tsx
+++ b/src/features/time-duration-calculator/components/time-form.tsx
@@ -35,7 +35,7 @@ export default function TimeForm({
 
       if (newEndTime.toString() === "Invalid Date") {
         // Generate today's date and add user-defined time
-        newStartTime = createDate(`${getDateInDateStringFormat()} ${endTime}`);
+        newEndTime = createDate(`${getDateInDateStringFormat()} ${endTime}`);
       }
 
       onError(false);


### PR DESCRIPTION
Fixes issue #1.

When the submit handler function was checking to see if the new end time variable value was `"Invalid Date"`, it generated a new date for the new start time variable instead of the new end time variable. Replacing the variable with `newEndTime` fixed the issue.