### PR TITLE
Add padding to the Y-axis

### DIFF
--- a/src/components/error-message.tsx
+++ b/src/components/error-message.tsx
@@ -1,6 +1,6 @@
 export default function ErrorMessage({ message }: { message: string }) {
   return (
-    <div className="my-4 flex h-10 items-center rounded-lg border border-red-200 bg-red-100 px-4">
+    <div className="my-4 flex items-center rounded-lg border border-red-200 bg-red-100 px-4 py-2">
       <p className="text-sm font-medium text-red-500">{message}</p>
     </div>
   );


### PR DESCRIPTION
## Description
Updated the error component `<ErrorMessage />` by removing the Tailwind CSS class `h-10` and replacing it with the class `py-2`.

## Changes
- [x] Removed Tailwind CSS class `h-10`
- [x] Added Tailwind CSS class `py-2`

## Checklist
- [x] Tested locally
- [x] No breaking changes

## Related Issues
Fixes issue #10.